### PR TITLE
retrieve versions & meta with reverse dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 * Add 4 missing type fields for Crate {recent_downloads, exact_match} and Version {crate_size, published_by}
 * Make field optional: User {kind} 
+* Fix getting the reverse dependencies.
+  * Rearrange the received data for simpler manipulation.
+  * Add 3 new types:
+    * ReverseDependenciesAsReceived {dependencies, versions, meta}
+    * ReverseDependencies {dependencies, meta}
+    * ReverseDependency {crate_version, dependency}
 
 ## 0.4.1 - 2019/03/09
 

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -106,19 +106,8 @@ impl Client {
             c.get::<ReverseDependenciesAsReceived>(&url).and_then(move |rdeps|
                 -> Box<Future<Item = ReverseDependencies, Error = Error> + Send> {
 
-                for d in rdeps.dependencies.iter() {
-                    for v in rdeps.versions.iter() {
-                        if v.id == d.version_id {
-                            // Right now it iterates over the full vector for each vector element.
-                            // For large vectors, it may be faster to remove each matched element
-                            // using the drain_filter() method once it's stabilized:
-                            // https://doc.rust-lang.org/nightly/std/vec/struct.Vec.html#method.drain_filter
-                            tidy_rdeps.dependencies.push(
-                                ReverseDependency {crate_version: v.clone(), dependency: d.clone()}
-                            );
-                        }
-                    }
-                }
+                tidy_rdeps.from_received(&rdeps);
+
                 if !rdeps.dependencies.is_empty() {
                     tidy_rdeps.meta = rdeps.meta;
                     Box::new(fetch_page(c, name, tidy_rdeps, page + 1))

--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -104,7 +104,7 @@ impl Client {
             )).unwrap();
 
             c.get::<ReverseDependenciesAsReceived>(&url).and_then(move |rdeps|
-                -> Box<Future<Item = ReverseDependencies, Error = Error> + Send> {
+                -> Box<dyn Future<Item = ReverseDependencies, Error = Error> + Send> {
 
                 tidy_rdeps.from_received(&rdeps);
 

--- a/src/sync_client.rs
+++ b/src/sync_client.rs
@@ -99,20 +99,7 @@ impl SyncClient {
 
             rdeps = self.get(url)?;
 
-            // match each dependency in deps with its version in vers
-            for d in rdeps.dependencies.iter() {
-                for v in rdeps.versions.iter() {
-                    if v.id == d.version_id {
-                        // Right now it iterates over the full vector for each vector element.
-                        // For large vectors, it may be faster to remove each matched element
-                        // using the drain_filter() method once it's stabilized:
-                        // https://doc.rust-lang.org/nightly/std/vec/struct.Vec.html#method.drain_filter
-                        tidy_rdeps.dependencies.push(
-                            ReverseDependency {crate_version: v.clone(), dependency: d.clone()}
-                        );
-                    }
-                }
-            }
+            tidy_rdeps.from_received(&rdeps);
 
             if !rdeps.dependencies.is_empty() {
                 tidy_rdeps.meta = rdeps.meta;

--- a/src/types.rs
+++ b/src/types.rs
@@ -244,6 +244,28 @@ pub struct ReverseDependencies {
     pub meta: Meta
 }
 
+impl ReverseDependencies {
+
+    /// Fills the dependencies field from a ReverseDependenciesAsReceived struct.
+    pub(crate) fn from_received(&mut self, rdeps: &ReverseDependenciesAsReceived) {
+
+        for d in rdeps.dependencies.iter() {
+            for v in rdeps.versions.iter() {
+                if v.id == d.version_id {
+                    // Right now it iterates over the full vector for each vector element.
+                    // For large vectors, it may be faster to remove each matched element
+                    // using the drain_filter() method once it's stabilized:
+                    // https://doc.rust-lang.org/nightly/std/vec/struct.Vec.html#method.drain_filter
+                    self.dependencies.push(
+                        ReverseDependency {crate_version: v.clone(), dependency: d.clone()}
+                    );
+                }
+            }
+        }
+    }
+}
+
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FullVersion {
     pub created_at: DateTime<Utc>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -224,6 +224,27 @@ pub struct Dependencies {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReverseDependency {
+  pub crate_version: Version,
+  pub dependency: Dependency,
+}
+
+// This is how reverse dependencies are received
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReverseDependenciesAsReceived {
+    pub dependencies: Vec<Dependency>,
+    pub versions: Vec<Version>,
+    pub meta: Meta
+}
+
+// This is how reverse dependencies are presented
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ReverseDependencies {
+    pub dependencies: Vec<ReverseDependency>,
+    pub meta: Meta
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct FullVersion {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -260,7 +281,7 @@ pub struct FullCrate {
     pub keywords: Vec<Keyword>,
     pub downloads: Downloads,
     pub owners: Vec<User>,
-    pub reverse_dependencies: Vec<Dependency>,
+    pub reverse_dependencies: ReverseDependencies,
 
     pub versions: Vec<FullVersion>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -231,7 +231,7 @@ pub struct ReverseDependency {
 
 // This is how reverse dependencies are received
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct ReverseDependenciesAsReceived {
+pub(super) struct ReverseDependenciesAsReceived {
     pub dependencies: Vec<Dependency>,
     pub versions: Vec<Version>,
     pub meta: Meta


### PR DESCRIPTION
fixes: #8 

Made crate_reverse_dependencies() return a tuple of the three available API elements. Note: only the sync version really fetches the fields, while the async version uses a placeholder.

This is a working example. Save as `src/bin/new-rev-dep.rs` and run `cargo run` to check:
```rust
extern crate crates_io_api;
use crates_io_api::SyncClient;

fn main() {
    let client = SyncClient::new();
    let crate_name = "hyper-native-tls";
    let (revdep, revvers, meta) = client.crate_reverse_dependencies(crate_name).unwrap();

    println!("total={:?}", meta.total);
    println!("\ndependencies={:?}", revdep);
    println!("\nversions={:?}", revvers);
}
```
