### PR TITLE
Fix full_crate()

### DIFF
--- a/src/async_client.rs
+++ b/src/async_client.rs
@@ -218,10 +218,14 @@ impl Client {
         let dls = self.crate_downloads(name);
         let owners = self.crate_owners(name);
         let reverse_dependencies = self.crate_reverse_dependencies(name);
+        // TODO:
+        // let (reverse_dependencies, reverse_dependencies_versions, reverse_dependencies_total) = self.crate_reverse_dependencies(name);
+        let reverse_dependencies_versions = Vec::new();
+        let reverse_dependencies_meta = Meta {total:0};
 
         crate_and_versions
             .join4(dls, owners, reverse_dependencies)
-            .map(|((resp, versions), dls, owners, reverse_dependencies)| {
+            .map(move |((resp, versions), dls, owners, reverse_dependencies)| {
                 let data = resp.crate_data;
                 FullCrate {
                     id: data.id,
@@ -241,6 +245,8 @@ impl Client {
                     downloads: dls,
                     owners,
                     reverse_dependencies,
+                    reverse_dependencies_versions,
+                    reverse_dependencies_meta,
                     versions,
                 }
             })

--- a/src/types.rs
+++ b/src/types.rs
@@ -103,6 +103,8 @@ pub struct Version {
     pub license: Option<String>,
     pub readme_path: Option<String>,
     pub links: VersionLinks,
+    pub crate_size: Option<u64>,
+    pub published_by: Option<User>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -174,7 +176,7 @@ pub struct User {
     pub avatar: Option<String>,
     pub email: Option<String>,
     pub id: u64,
-    pub kind: String,
+    pub kind: Option<String>,
     pub login: String,
     pub name: Option<String>,
     pub url: String,
@@ -218,6 +220,8 @@ pub struct Dependency {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Dependencies {
     pub dependencies: Vec<Dependency>,
+    pub versions: Vec<Version>,
+    pub meta: Meta,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -258,6 +262,8 @@ pub struct FullCrate {
     pub downloads: Downloads,
     pub owners: Vec<User>,
     pub reverse_dependencies: Vec<Dependency>,
+    pub reverse_dependencies_versions: Vec<Version>,
+    pub reverse_dependencies_meta: Meta,
 
     pub versions: Vec<FullVersion>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -150,7 +150,6 @@ pub struct Summary {
 pub struct VersionDownloads {
     pub date: NaiveDate,
     pub downloads: u64,
-    pub id: u64,
     pub version: u64,
 }
 


### PR DESCRIPTION
Fixes #7 

Removed unexistant `VersionDownloads.id` field

e.g. `https://crates.io/api/v1/crates/hyper-native-tls/downloads`

This is a working example. Save as `src/bin/fix-fullcrate.rs` and run `cargo run --bin fix-fullcrate` to check:
```rust
extern crate crates_io_api;
use crates_io_api::SyncClient;

fn main() {
    let client = SyncClient::new();
    let crate_name = "hyper-native-tls";
    let c = client.full_crate(crate_name, false).unwrap();
    println!("name={}", c.name);
}
```