### PR TITLE
Make SyncClient thread-safe.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.stdenv.mkDerivation {
+  name = "cratesioapi";
+  buildInputs = with pkgs; [
+      pkgconfig
+      lld_9
+      openssl
+  ];
+
+  shellHook = ''
+    # Use lld as a linker.
+    export RUSTFLAGS="-C link-arg=-fuse-ld=lld"
+    export LD_LIBRARY_PATH="${pkgs.openssl.out}/lib:$LD_LIBRARY_PATH"
+  '';
+}


### PR DESCRIPTION
Replaces an internal `RefCell` with a `Mutex` to make the SyncClient `Send`/`Sync`.

Fixes #21.