### PR TITLE
Remove old time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 version = "0.7.2-alpha.0"
 
 [dependencies]
-chrono = { version = "0.4.6", features = ["serde"] }
+chrono = { version = "0.4.6", default-features = false, features = ["serde", "std"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = "1.0.79"
 serde_derive = "1.0.79"


### PR DESCRIPTION
Chrono has a default `oldtime` feature flag, and this crate is enabling it without using it. I'd like to remove duplicate `time` crate from my project, so I need all deps to stop implicitly asking for it.