### PR TITLE
Work without openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.7.3-alpha.0"
 
 [dependencies]
 chrono = { version = "0.4.6", default-features = false, features = ["serde"] }
-reqwest = { version = "0.11", features = ["blocking", "json"] }
+reqwest = { version = "0.11", default-features = false, features = ["blocking", "json"] }
 serde = "1.0.79"
 serde_derive = "1.0.79"
 serde_json = "1.0.32"
@@ -25,3 +25,7 @@ tokio = { version = "1.0.1", default-features = false, features = ["sync", "time
 
 [dev-dependencies]
 tokio = "1.0.1"
+
+[features]
+default = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]


### PR DESCRIPTION
Pure rust makes it easier to compile.